### PR TITLE
appcompat-v7:25.1.1 -> appcompat-v7:27.1.1

### DIFF
--- a/constraintlayout/build.gradle
+++ b/constraintlayout/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     testCompile 'junit:junit:4.12'
     compile 'com.android.support.constraint:constraint-layout:1.1.2'
 }


### PR DESCRIPTION
appcompat-v7:25.1.1 -> appcompat-v7:27.1.1 because compile sdk version is 27
Older library caused build to fail.