### PR TITLE
Align the container id when using a simple CoordinatorLayout

### DIFF
--- a/motionlayout/src/main/res/layout/motion_11_coordinatorlayout.xml
+++ b/motionlayout/src/main/res/layout/motion_11_coordinatorlayout.xml
@@ -15,7 +15,7 @@
   -->
 <android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/content"
+    android:id="@+id/motionLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="false"


### PR DESCRIPTION
Fix #28 