### PR TITLE
Update examples to use ConstraintLayout 2.0.0 alpha 4 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         targetSdkVersion = 28
 
         appCompatVersion = '1.1.0-alpha03'
-        constraintLayoutVersion = '2.0.0-alpha3'
+        constraintLayoutVersion = '2.0.0-alpha4'
         glideVersion = '4.8.0'
         kotlinVersion = '1.3.11'
         lifeCycleVersion = '2.0.0'

--- a/motionlayout/src/main/res/xml/list_scene.xml
+++ b/motionlayout/src/main/res/xml/list_scene.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear" />
+        motion:motionInterpolator="linear" />
 
     <ConstraintSet android:id="@+id/start">
     </ConstraintSet>

--- a/motionlayout/src/main/res/xml/main_scene.xml
+++ b/motionlayout/src/main/res/xml/main_scene.xml
@@ -21,7 +21,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear" />
+        motion:motionInterpolator="linear" />
 
     <OnSwipe
         motion:touchAnchorId="@+id/container"

--- a/motionlayout/src/main/res/xml/rv_scene.xml
+++ b/motionlayout/src/main/res/xml/rv_scene.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear" />
+        motion:motionInterpolator="linear" />
 
     <OnSwipe
         motion:touchAnchorId="@+id/rv_item_placeholder"

--- a/motionlayout/src/main/res/xml/scene_03.xml
+++ b/motionlayout/src/main/res/xml/scene_03.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:dragDirection="dragRight"
             motion:touchAnchorId="@id/button"

--- a/motionlayout/src/main/res/xml/scene_06.xml
+++ b/motionlayout/src/main/res/xml/scene_06.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/button"
             motion:touchAnchorSide="right"
@@ -32,7 +32,7 @@
                 motion:keyPositionType="pathRelative"
                 motion:percentY="-0.25"
                 motion:framePosition="50"
-                motion:target="@id/button"/>
+                motion:motionTarget="@id/button"/>
         </KeyFrameSet>
     </Transition>
     

--- a/motionlayout/src/main/res/xml/scene_07.xml
+++ b/motionlayout/src/main/res/xml/scene_07.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/button"
             motion:touchAnchorSide="right"
@@ -65,12 +65,12 @@
                 android:scaleY="2"
                 android:rotation="-45"
                 motion:framePosition="50"
-                motion:target="@id/button" />
+                motion:motionTarget="@id/button" />
             <KeyPosition
                 motion:keyPositionType="pathRelative"
                 motion:percentY="-0.3"
                 motion:framePosition="50"
-                motion:target="@id/button"/>
+                motion:motionTarget="@id/button"/>
         </KeyFrameSet>
     </Transition>
 

--- a/motionlayout/src/main/res/xml/scene_08.xml
+++ b/motionlayout/src/main/res/xml/scene_08.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/button"
             motion:touchAnchorSide="right"
@@ -63,21 +63,21 @@
             <KeyCycle
                 android:translationY="50dp"
                 motion:framePosition="100"
-                motion:target="@id/button"
+                motion:motionTarget="@id/button"
                 motion:waveOffset="0"
                 motion:wavePeriod="0"
                 motion:waveShape="sin" />
             <KeyCycle
                 android:translationY="50dp"
                 motion:framePosition="50"
-                motion:target="@id/button"
+                motion:motionTarget="@id/button"
                 motion:waveOffset="0"
                 motion:wavePeriod="1"
                 motion:waveShape="sin" />
             <KeyCycle
                 android:translationY="50dp"
                 motion:framePosition="0"
-                motion:target="@id/button"
+                motion:motionTarget="@id/button"
                 motion:waveOffset="0"
                 motion:wavePeriod="0"
                 motion:waveShape="sin" />

--- a/motionlayout/src/main/res/xml/scene_09.xml
+++ b/motionlayout/src/main/res/xml/scene_09.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/background"
             motion:touchAnchorSide="bottom"

--- a/motionlayout/src/main/res/xml/scene_10_header.xml
+++ b/motionlayout/src/main/res/xml/scene_10_header.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/background"
             motion:touchAnchorSide="bottom"

--- a/motionlayout/src/main/res/xml/scene_11_header.xml
+++ b/motionlayout/src/main/res/xml/scene_11_header.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <ConstraintSet android:id="@+id/start">
 

--- a/motionlayout/src/main/res/xml/scene_12_content.xml
+++ b/motionlayout/src/main/res/xml/scene_12_content.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <ConstraintSet android:id="@+id/start">
             <Constraint

--- a/motionlayout/src/main/res/xml/scene_13_menu.xml
+++ b/motionlayout/src/main/res/xml/scene_13_menu.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <ConstraintSet android:id="@+id/start">
             <Constraint

--- a/motionlayout/src/main/res/xml/scene_14.xml
+++ b/motionlayout/src/main/res/xml/scene_14.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/button"
             motion:touchAnchorSide="right"

--- a/motionlayout/src/main/res/xml/scene_15.xml
+++ b/motionlayout/src/main/res/xml/scene_15.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/car"

--- a/motionlayout/src/main/res/xml/scene_17.xml
+++ b/motionlayout/src/main/res/xml/scene_17.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/motionLayout"
@@ -49,7 +49,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:progress="1"/>
+                motion:motionProgress="1"/>
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_17.xml
+++ b/motionlayout/src/main/res/xml/scene_17.xml
@@ -49,7 +49,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:motionProgress="1"/>
+                motion:progress="1"/>
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_17_header.xml
+++ b/motionlayout/src/main/res/xml/scene_17_header.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/background"
             motion:touchAnchorSide="bottom"

--- a/motionlayout/src/main/res/xml/scene_18.xml
+++ b/motionlayout/src/main/res/xml/scene_18.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/motionLayout"
@@ -59,7 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:progress="1" />
+                motion:motionProgress="1" />
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_18.xml
+++ b/motionlayout/src/main/res/xml/scene_18.xml
@@ -59,7 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:motionProgress="1" />
+                motion:progress="1" />
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_19.xml
+++ b/motionlayout/src/main/res/xml/scene_19.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/motionLayout"
@@ -59,7 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:progress="1" />
+                motion:motionProgress="1" />
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_19.xml
+++ b/motionlayout/src/main/res/xml/scene_19.xml
@@ -59,7 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:motionProgress="1" />
+                motion:progress="1" />
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_19_header.xml
+++ b/motionlayout/src/main/res/xml/scene_19_header.xml
@@ -21,7 +21,7 @@
         motion:constraintSetStart="@+id/start"
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
         <OnSwipe
             motion:touchAnchorId="@+id/background"
             motion:touchAnchorSide="bottom"

--- a/motionlayout/src/main/res/xml/scene_20.xml
+++ b/motionlayout/src/main/res/xml/scene_20.xml
@@ -124,7 +124,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/imageView8"
@@ -134,12 +134,12 @@
             <KeyAttribute
                 android:rotation="0"
                 motion:framePosition="1"
-                motion:target="@id/imageView9" />
+                motion:motionTarget="@id/imageView9" />
             <KeyPosition
                 motion:framePosition="27"
                 motion:percentX="-0.2585034"
                 motion:percentY="0.50630915"
-                motion:target="@id/imageView9"
+                motion:motionTarget="@id/imageView9"
                 motion:keyPositionType="deltaRelative" />
         </KeyFrameSet>
     </Transition>

--- a/motionlayout/src/main/res/xml/scene_21_second_fragment.xml
+++ b/motionlayout/src/main/res/xml/scene_21_second_fragment.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear" />
+        motion:motionInterpolator="linear" />
 
     <ConstraintSet android:id="@+id/start">
         <Constraint

--- a/motionlayout/src/main/res/xml/scene_23.xml
+++ b/motionlayout/src/main/res/xml/scene_23.xml
@@ -27,7 +27,7 @@
             android:id="@id/animation_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            motion:progress="0"/>
+            motion:motionProgress="0"/>
     </ConstraintSet>
 
     <ConstraintSet android:id="@+id/end">
@@ -35,7 +35,7 @@
             android:id="@id/animation_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            motion:progress="1"/>
+            motion:motionProgress="1"/>
     </ConstraintSet>
 
 </MotionScene>

--- a/motionlayout/src/main/res/xml/scene_23.xml
+++ b/motionlayout/src/main/res/xml/scene_23.xml
@@ -27,7 +27,7 @@
             android:id="@id/animation_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            motion:motionProgress="0"/>
+            motion:progress="0"/>
     </ConstraintSet>
 
     <ConstraintSet android:id="@+id/end">
@@ -35,7 +35,7 @@
             android:id="@id/animation_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            motion:motionProgress="1"/>
+            motion:progress="1"/>
     </ConstraintSet>
 
 </MotionScene>

--- a/motionlayout/src/main/res/xml/scene_24.xml
+++ b/motionlayout/src/main/res/xml/scene_24.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="1000"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/top_image_container"
@@ -152,7 +152,7 @@
         <KeyFrameSet>
 
             <KeyPosition
-                motion:target="@id/top_image"
+                motion:motionTarget="@id/top_image"
                 motion:framePosition="90"
                 motion:percentWidth="0"
                 motion:percentX="0"
@@ -160,14 +160,14 @@
                 />
 
             <KeyPosition
-                motion:target="@id/top_image_container"
+                motion:motionTarget="@id/top_image_container"
                 motion:framePosition="90"
                 motion:percentWidth="0"
                 motion:curveFit="linear"
                 />
 
             <KeyPosition
-                motion:target="@id/recyclerview_container"
+                motion:motionTarget="@id/recyclerview_container"
                 motion:framePosition="90"
                 motion:percentWidth="0"
                 motion:curveFit="linear"
@@ -176,17 +176,17 @@
             <KeyAttribute
                 android:alpha="0"
                 motion:framePosition="75"
-                motion:target="@id/recyclerview_front" />
+                motion:motionTarget="@id/recyclerview_front" />
 
             <KeyAttribute
                 android:alpha="0.10"
                 motion:framePosition="90"
-                motion:target="@id/image_clear" />
+                motion:motionTarget="@id/image_clear" />
 
             <KeyAttribute
                 android:alpha="0.10"
                 motion:framePosition="90"
-                motion:target="@id/image_play" />
+                motion:motionTarget="@id/image_play" />
         </KeyFrameSet>
     </Transition>
 

--- a/motionlayout/src/main/res/xml/scene_25.xml
+++ b/motionlayout/src/main/res/xml/scene_25.xml
@@ -68,7 +68,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:motionProgress="1" />
+                motion:progress="1" />
 
             <Constraint
                 android:id="@id/scrollable"

--- a/motionlayout/src/main/res/xml/scene_25.xml
+++ b/motionlayout/src/main/res/xml/scene_25.xml
@@ -20,7 +20,7 @@
         motion:constraintSetEnd="@+id/end"
         motion:constraintSetStart="@+id/start"
         motion:duration="250"
-        motion:interpolator="linear">
+        motion:motionInterpolator="linear">
 
         <OnSwipe
             motion:touchAnchorId="@+id/motionLayout"
@@ -35,7 +35,7 @@
             <KeyTrigger
                 motion:framePosition="10"
                 motion:onPositiveCross="show"
-                motion:target="@id/fab"/>
+                motion:motionTarget="@id/fab"/>
 
             <!--
             Calls FloatingActionButton.hide() when frame position is being decreased and
@@ -44,7 +44,7 @@
             <KeyTrigger
                 motion:framePosition="20"
                 motion:onNegativeCross="hide"
-                motion:target="@id/fab"/>
+                motion:motionTarget="@id/fab"/>
         </KeyFrameSet>
 
         <ConstraintSet android:id="@+id/start">
@@ -68,7 +68,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 motion:layout_constraintTop_toTopOf="parent"
-                motion:progress="1" />
+                motion:motionProgress="1" />
 
             <Constraint
                 android:id="@id/scrollable"


### PR DESCRIPTION
Updated the dependency to the latest alpha version and renamed properties in motion scene files as necessary. Checked out all the different examples and there is no visible difference in animations that I can see between alpha 3 and alpha 4.

https://androidstudio.googleblog.com/2019/04/constraintlayout-200-alpha-4.html